### PR TITLE
[fix] Fixed Dad Joke Generator Not Retrieving Dad Joke

### DIFF
--- a/dadjoke.js
+++ b/dadjoke.js
@@ -3,7 +3,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     jQuery.ajax({
         method: 'GET',
-        url: 'https://api.api-ninjas.com/v1/dadjokes?limit=1',
+        url: 'https://api.api-ninjas.com/v1/dadjokes',
         headers: { 'X-Api-Key': 'NkJn71G/TN0GtboS5seTgg==0ebYg4DWFK1pd0lp' },
         contentType: 'application/json',
         success: function(result) {


### PR DESCRIPTION
On the 404 page, the API I use to pull dad jokes changed their policy from allowing unrestricted users to use a limit query. I removed this limit query to fix the bug.