### PR TITLE
[fix] Updated copyright year on all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -96,7 +96,7 @@
             </section>
         </div>
         <footer>
-            <p>© 2024 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
+            <p>© 2025 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
         </footer>
         <div class="mobile-footer-margin">&nbsp;</div>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -86,7 +86,7 @@
             </section>
         </div>
         <footer>
-          <p>© 2024 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
+          <p>© 2025 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
         </footer>
         <div class="footer-margin">&nbsp;</div>
     </div>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
             </div>
         </div>
         <footer>
-            <p>© 2024 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
+            <p>© 2025 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
         </footer>
         <div class="footer-margin">&nbsp;</div>
     </div>

--- a/projects.html
+++ b/projects.html
@@ -134,7 +134,7 @@
             </div>
         </div>
         <footer>
-            <p>© 2024 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
+            <p>© 2025 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
         </footer>
         <div class="footer-margin">&nbsp;</div>
         <div id="modal-popout" class="modal">

--- a/resume.html
+++ b/resume.html
@@ -65,7 +65,7 @@
             </section>
         </div>
         <footer>
-            <p>© 2024 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
+            <p>© 2025 Dylan Ravel — <a class="all-rights-reserved" href="./privacy-policy"><i class="fa-solid fa-arrow-up-right-from-square"></i> All rights reserved</a>.</p>
         </footer>
         <div class="footer-margin">&nbsp;</div>
     </div>


### PR DESCRIPTION
This pull request updates the copyright year across multiple HTML files.

Changes include:

* [`404.html`](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL99-R99): Updated the year from 2024 to 2025 in the footer.
* [`contact.html`](diffhunk://#diff-eb5639ef0321321f5581e73866a7db6fb2c6d9d2fdbebafc7445f538e7078309L89-R89): Updated the year from 2024 to 2025 in the footer.
* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L117-R117): Updated the year from 2024 to 2025 in the footer.
* [`projects.html`](diffhunk://#diff-fe6ac85fb2ded08a8f3f0e986696c14dff0595f2374ccdb2beb7b339f98c23b8L137-R137): Updated the year from 2024 to 2025 in the footer.
* [`resume.html`](diffhunk://#diff-704b6b230367678bdfb4bf24f6d002dd6f58b94af9b57a04aacc3b68fdf59f84L68-R68): Updated the year from 2024 to 2025 in the footer.